### PR TITLE
Update withStyle.d.ts

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -43,6 +43,6 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
   options?: WithStylesOptions,
-): <P extends WithStyles<ClassKey>>(
-  component: React.ComponentType<P>,
-) => React.ComponentType<Omit<P, keyof WithStyles<ClassKey>> & StyledComponentProps<ClassKey>>;
+): <P>(
+  component: React.ComponentType<P & WithStyles<ClassKey>>,
+) => React.ComponentType<Omit<P, keyof WithStyles<ClassKey> & keyof P> & StyledComponentProps<ClassKey>>;


### PR DESCRIPTION
Improve withStyles() typescript definition to reflect that `classes` and `theme` are optional in the styled component even if required in the base component.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
